### PR TITLE
remove unnecessary comma in crmsci@1.2.6 to make it valid json

### DIFF
--- a/datasets/admsv@1.0.json
+++ b/datasets/admsv@1.0.json
@@ -5,7 +5,7 @@
   ],
   "description": "This dataset specifies the controlled vocabularies defined by [ADMS](/w3c/adms) v1.0 as [SKOS](/w3c/skos) concept schemes and SKOS concepts.",
   "id": "isa/admsv@1.0",
-  "_license": "https://joinup.ec.europa.eu/category/licence/isa-open-metadata-licence-v11",
+  "license": "https://joinup.ec.europa.eu/category/licence/isa-open-metadata-licence-v11",
   "name": "Controlled vocabularies for the Asset Description Metadata Schema",
   "prefix": {
     "admsv": "http://purl.org/adms/"

--- a/datasets/crmsci@1.2.6.json
+++ b/datasets/crmsci@1.2.6.json
@@ -10,7 +10,7 @@
   "image": "crmsci.jpg",
   "name": "CRMsci",
   "prefix": {
-    "crmsci": "http://www.ics.forth.gr/isl/CRMsci/",
+    "crmsci": "http://www.ics.forth.gr/isl/CRMsci/"
   },
   "url": "http://www.cidoc-crm.org/crmsci/sites/default/files/CRMsci_v1.2.6.rdfs"
 }


### PR DESCRIPTION
While working with the datasets, my script bumped into json error on this particular dataset `crmsci@1.2.6`. The problem is the comma after last element in a dictionary. This is not allowed by json hence the invalid json error. 

Since I am not the creator of dataset, I am not sure whether this PR should be created at all. Please feel free to either inform the author(s) and let them fix it or merge the PR after checking. Thanks!!